### PR TITLE
Send note

### DIFF
--- a/crates/apub-activitypub/src/core.rs
+++ b/crates/apub-activitypub/src/core.rs
@@ -1,4 +1,3 @@
 pub mod activity;
 pub mod actor;
 pub mod object;
-pub mod collection;

--- a/crates/apub-activitypub/src/core.rs
+++ b/crates/apub-activitypub/src/core.rs
@@ -1,3 +1,4 @@
 pub mod activity;
 pub mod actor;
 pub mod object;
+pub mod collection;

--- a/crates/apub-activitypub/src/model.rs
+++ b/crates/apub-activitypub/src/model.rs
@@ -1,4 +1,5 @@
 pub mod activity;
+pub mod collection;
 pub mod context;
 pub mod key;
 pub mod note;

--- a/crates/apub-activitypub/src/model/collection.rs
+++ b/crates/apub-activitypub/src/model/collection.rs
@@ -118,11 +118,23 @@ impl<T> OrderedCollection<T> {
 }
 
 /// `Collection` or `OrderedCollection`
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AnyCollection<T> {
     Collection(Collection<T>),
     OrderedCollection(OrderedCollection<T>),
+}
+
+impl<T> From<Collection<T>> for AnyCollection<T> {
+    fn from(value: Collection<T>) -> Self {
+        AnyCollection::Collection(value)
+    }
+}
+
+impl<T> From<OrderedCollection<T>> for AnyCollection<T> {
+    fn from(value: OrderedCollection<T>) -> Self {
+        AnyCollection::OrderedCollection(value)
+    }
 }
 
 impl<T> AnyCollection<T> {
@@ -256,11 +268,23 @@ impl<T> OrderedCollectionPage<T> {
 }
 
 /// `CollectionPage` or `OrderedCollectionPage`
-#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AnyCollectionPage<T> {
     CollectionPage(CollectionPage<T>),
     OrderedCollectionPage(OrderedCollectionPage<T>),
+}
+
+impl<T> From<CollectionPage<T>> for AnyCollectionPage<T> {
+    fn from(value: CollectionPage<T>) -> Self {
+        AnyCollectionPage::CollectionPage(value)
+    }
+}
+
+impl<T> From<OrderedCollectionPage<T>> for AnyCollectionPage<T> {
+    fn from(value: OrderedCollectionPage<T>) -> Self {
+        AnyCollectionPage::OrderedCollectionPage(value)
+    }
 }
 
 impl<T> AnyCollectionPage<T> {

--- a/crates/apub-activitypub/src/model/collection.rs
+++ b/crates/apub-activitypub/src/model/collection.rs
@@ -1,0 +1,508 @@
+use apub_shared::model::{id::UrlId, resource_url::ResourceUrl};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use typed_builder::TypedBuilder;
+
+use crate::core::object::Object;
+
+use super::context::Context;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub enum CollectionKind {
+    #[default]
+    Collection,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub enum OrderedCollectionKind {
+    #[default]
+    OrderedCollection,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub enum CollectionPageKind {
+    #[default]
+    CollectionPage,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub enum OrderedCollectionPageKind {
+    #[default]
+    OrderedCollectionPage,
+}
+
+/// Activity Collection
+///
+/// See
+/// - https://www.w3.org/TR/activitystreams-core/#collection
+/// - https://www.w3.org/TR/activitystreams-vocabulary/#dfn-collection
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[builder(field_defaults(setter(strip_option, into)))]
+pub struct Collection<T> {
+    #[serde(rename = "@context")]
+    context: Option<Context>,
+    id: Option<UrlId<Collection<T>>>,
+    #[serde(rename = "type")]
+    #[builder(default,setter(!strip_option))]
+    kind: CollectionKind,
+    #[serde(flatten)]
+    #[builder(setter(!strip_option))]
+    base: CollectionBase<T>,
+}
+
+impl<T> Object for Collection<T> {
+    type Kind = CollectionKind;
+}
+
+impl<T> Collection<T> {
+    pub fn id(&self) -> Option<&UrlId<Self>> {
+        self.id.as_ref()
+    }
+
+    pub fn items(&self) -> Option<&Vec<T>> {
+        self.base.items.as_ref()
+    }
+
+    pub fn total(&self) -> Option<usize> {
+        self.base.total_items
+    }
+
+    pub fn first(&self) -> Option<&ResourceUrl> {
+        self.base.first.as_ref()
+    }
+}
+
+/// Activity OrderedCollection
+///
+/// See
+/// - https://www.w3.org/TR/activitystreams-core/#collection
+/// - https://www.w3.org/TR/activitystreams-vocabulary/#dfn-orderedcollection
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[builder(field_defaults(setter(strip_option, into)))]
+pub struct OrderedCollection<T> {
+    #[serde(rename = "@context")]
+    context: Option<Context>,
+    id: Option<UrlId<OrderedCollection<T>>>,
+    #[serde(rename = "type")]
+    #[builder(default,setter(!strip_option))]
+    kind: OrderedCollectionKind,
+    #[serde(flatten)]
+    #[builder(setter(!strip_option))]
+    base: OrderedCollectionBase<T>,
+}
+
+impl<T> Object for OrderedCollection<T> {
+    type Kind = OrderedCollectionKind;
+}
+
+impl<T> OrderedCollection<T> {
+    pub fn id(&self) -> Option<&UrlId<Self>> {
+        self.id.as_ref()
+    }
+
+    pub fn items(&self) -> Option<&Vec<T>> {
+        self.base.ordered_items.as_ref()
+    }
+
+    pub fn total(&self) -> Option<usize> {
+        self.base.total_items
+    }
+
+    pub fn first(&self) -> Option<&ResourceUrl> {
+        self.base.first.as_ref()
+    }
+}
+
+/// `Collection` or `OrderedCollection`
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum AnyCollection<T> {
+    Collection(Collection<T>),
+    OrderedCollection(OrderedCollection<T>),
+}
+
+impl<T> AnyCollection<T> {
+    pub fn id(&self) -> Option<&ResourceUrl> {
+        match self {
+            AnyCollection::Collection(c) => c.id().map(|v| v.as_ref()),
+            AnyCollection::OrderedCollection(c) => c.id().map(|v| v.as_ref()),
+        }
+    }
+
+    pub fn items(&self) -> Option<&Vec<T>> {
+        match self {
+            AnyCollection::Collection(c) => c.items(),
+            AnyCollection::OrderedCollection(c) => c.items(),
+        }
+    }
+
+    pub fn total(&self) -> Option<usize> {
+        match self {
+            AnyCollection::Collection(c) => c.total(),
+            AnyCollection::OrderedCollection(c) => c.total(),
+        }
+    }
+
+    pub fn first(&self) -> Option<&ResourceUrl> {
+        match self {
+            AnyCollection::Collection(c) => c.first(),
+            AnyCollection::OrderedCollection(c) => c.first(),
+        }
+    }
+}
+
+/// Activity CollectionPage
+///
+/// See
+/// - https://www.w3.org/TR/activitystreams-core/#paging
+/// - https://www.w3.org/TR/activitystreams-vocabulary/#dfn-collectionpage
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[builder(field_defaults(setter(strip_option)))]
+pub struct CollectionPage<T> {
+    #[serde(rename = "@context")]
+    context: Option<Context>,
+    id: Option<UrlId<CollectionPage<T>>>,
+    #[serde(rename = "type")]
+    #[builder(default,setter(!strip_option))]
+    kind: CollectionPageKind,
+    #[serde(flatten)]
+    #[builder(setter(!strip_option))]
+    base: CollectionBase<T>,
+    #[serde(flatten)]
+    #[builder(setter(!strip_option))]
+    page: CollectionPageBase,
+}
+
+impl<T> Object for CollectionPage<T> {
+    type Kind = CollectionPageKind;
+}
+
+impl<T> CollectionPage<T> {
+    pub fn id(&self) -> Option<&UrlId<Self>> {
+        self.id.as_ref()
+    }
+
+    pub fn items(&self) -> Option<&Vec<T>> {
+        self.base.items.as_ref()
+    }
+
+    pub fn total(&self) -> Option<usize> {
+        self.base.total_items
+    }
+
+    pub fn next(&self) -> Option<&ResourceUrl> {
+        self.page.next.as_ref()
+    }
+
+    pub fn prev(&self) -> Option<&ResourceUrl> {
+        self.page.prev.as_ref()
+    }
+}
+
+/// Activity OrderedCollectionPage
+///
+/// See
+/// - https://www.w3.org/TR/activitystreams-core/#paging
+/// - https://www.w3.org/TR/activitystreams-vocabulary/#dfn-orderedcollectionpage
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[builder(field_defaults(setter(strip_option)))]
+pub struct OrderedCollectionPage<T> {
+    #[serde(rename = "@context")]
+    context: Option<Context>,
+    id: Option<UrlId<OrderedCollectionPage<T>>>,
+    #[serde(rename = "type")]
+    #[builder(default,setter(!strip_option))]
+    kind: OrderedCollectionPageKind,
+    #[serde(flatten)]
+    #[builder(setter(!strip_option))]
+    base: OrderedCollectionBase<T>,
+    #[serde(flatten)]
+    #[builder(setter(!strip_option))]
+    page: CollectionPageBase,
+}
+
+impl<T> Object for OrderedCollectionPage<T> {
+    type Kind = OrderedCollectionPageKind;
+}
+
+impl<T> OrderedCollectionPage<T> {
+    pub fn id(&self) -> Option<&UrlId<Self>> {
+        self.id.as_ref()
+    }
+
+    pub fn items(&self) -> Option<&Vec<T>> {
+        self.base.ordered_items.as_ref()
+    }
+
+    pub fn total(&self) -> Option<usize> {
+        self.base.total_items
+    }
+
+    pub fn next(&self) -> Option<&ResourceUrl> {
+        self.page.next.as_ref()
+    }
+
+    pub fn prev(&self) -> Option<&ResourceUrl> {
+        self.page.prev.as_ref()
+    }
+}
+
+/// `CollectionPage` or `OrderedCollectionPage`
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(untagged)]
+pub enum AnyCollectionPage<T> {
+    CollectionPage(CollectionPage<T>),
+    OrderedCollectionPage(OrderedCollectionPage<T>),
+}
+
+impl<T> AnyCollectionPage<T> {
+    pub fn id(&self) -> Option<&ResourceUrl> {
+        match self {
+            AnyCollectionPage::CollectionPage(p) => p.id().map(|v| v.as_ref()),
+            AnyCollectionPage::OrderedCollectionPage(p) => p.id().map(|v| v.as_ref()),
+        }
+    }
+
+    pub fn items(&self) -> Option<&Vec<T>> {
+        match self {
+            AnyCollectionPage::CollectionPage(p) => p.items(),
+            AnyCollectionPage::OrderedCollectionPage(p) => p.items(),
+        }
+    }
+
+    pub fn total(&self) -> Option<usize> {
+        match self {
+            AnyCollectionPage::CollectionPage(p) => p.total(),
+            AnyCollectionPage::OrderedCollectionPage(p) => p.total(),
+        }
+    }
+
+    pub fn next(&self) -> Option<&ResourceUrl> {
+        match self {
+            AnyCollectionPage::CollectionPage(p) => p.next(),
+            AnyCollectionPage::OrderedCollectionPage(p) => p.next(),
+        }
+    }
+
+    pub fn prev(&self) -> Option<&ResourceUrl> {
+        match self {
+            AnyCollectionPage::CollectionPage(p) => p.prev(),
+            AnyCollectionPage::OrderedCollectionPage(p) => p.prev(),
+        }
+    }
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[builder(field_defaults(default, setter(strip_option)))]
+pub struct CollectionBase<T> {
+    total_items: Option<usize>,
+    items: Option<Vec<T>>,
+    first: Option<ResourceUrl>,
+    last: Option<ResourceUrl>,
+}
+
+impl<T> Default for CollectionBase<T> {
+    fn default() -> Self {
+        Self::builder().total_items(0).items(Vec::new()).build()
+    }
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[builder(field_defaults(default, setter(strip_option)))]
+pub struct OrderedCollectionBase<T> {
+    total_items: Option<usize>,
+    ordered_items: Option<Vec<T>>,
+    first: Option<ResourceUrl>,
+    last: Option<ResourceUrl>,
+}
+
+impl<T> Default for OrderedCollectionBase<T> {
+    fn default() -> Self {
+        Self::builder()
+            .total_items(0)
+            .ordered_items(Vec::new())
+            .build()
+    }
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
+#[builder(field_defaults(default, setter(strip_option)))]
+pub struct CollectionPageBase {
+    next: Option<ResourceUrl>,
+    prev: Option<ResourceUrl>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::model::note::Note;
+
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_serialize_collection() {
+        let collection = r#"
+            {
+                "@context": "https://www.w3.org/ns/activitystreams",
+                "id": "https://example.com/users/alice/followers",
+                "type": "Collection",
+                "totalItems": 2,
+                "items": [
+                    "https://example.com/users/bob",
+                    "https://example.com/users/charlie"
+                ]
+            }
+        "#;
+
+        let deserialized = serde_json::from_str(collection).unwrap();
+
+        let collection_base = CollectionBase::<_>::builder()
+            .items(
+                [
+                    "https://example.com/users/bob",
+                    "https://example.com/users/charlie",
+                ]
+                .into_iter()
+                .map(|s| s.parse().unwrap())
+                .collect(),
+            )
+            .total_items(2)
+            .build();
+        let expected = Collection::<ResourceUrl>::builder()
+            .base(collection_base)
+            .context(Context::default())
+            .id("https://example.com/users/alice/followers"
+                .parse::<UrlId<_>>()
+                .unwrap())
+            .build();
+
+        assert_eq!(expected, deserialized)
+    }
+
+    #[test]
+    fn test_serialize_ordered_collection() {
+        let collection = r#"
+            {
+                "@context": "https://www.w3.org/ns/activitystreams",
+                "id": "https://example.com/users/alice/outbox",
+                "type": "OrderedCollection",
+                "totalItems": 1,
+                "orderedItems": [
+                    {
+                        "id": "https://example.com/users/alice/statuses/1",
+                        "type": "Note",
+                        "content": "Hello World!"
+                    }
+                ]
+            }
+        "#;
+
+        let deserialized = serde_json::from_str(collection).unwrap();
+
+        let collection_base = OrderedCollectionBase::<_>::builder()
+            .ordered_items(vec![Note::builder()
+                .id("https://example.com/users/alice/statuses/1"
+                    .parse()
+                    .unwrap())
+                .content("Hello World!".into())
+                .build()])
+            .total_items(1)
+            .build();
+        let expected = OrderedCollection::<Note>::builder()
+            .base(collection_base)
+            .context(Context::default())
+            .id("https://example.com/users/alice/outbox"
+                .parse::<UrlId<_>>()
+                .unwrap())
+            .build();
+
+        assert_eq!(expected, deserialized)
+    }
+
+    #[test]
+    fn test_serialize_ordered_collection_page() {
+        // sampled from https://mastodon.social/users/Mastodon/collections/followers
+        let collection = r#"
+            {
+                "@context": "https://www.w3.org/ns/activitystreams",
+                "id": "https://example.com/users/User1/followers?page=1",
+                "type": "OrderedCollectionPage",
+                "totalItems": 822847,
+                "next": "https://example.com/users/User1/followers?page=2",
+                "partOf": "https://example.com/users/User1/followers",
+                "orderedItems": [
+                    "https://example.com/users/UserA",
+                    "https://example.com/users/UserB",
+                    "https://example.com/users/UserC",
+                    "https://example.com/users/UserD",
+                    "https://example.com/users/UserE",
+                    "https://example.com/users/UserF",
+                    "https://example.com/users/UserG",
+                    "https://example.com/users/UserH",
+                    "https://example.com/users/UserI",
+                    "https://example.com/users/UserJ",
+                    "https://example.com/users/UserK",
+                    "https://example.com/users/UserL"
+                ]
+            }
+        "#;
+
+        let deserialized = serde_json::from_str(collection).unwrap();
+
+        let collection_base = OrderedCollectionBase::<_>::builder()
+            .ordered_items(
+                [
+                    "https://example.com/users/UserA",
+                    "https://example.com/users/UserB",
+                    "https://example.com/users/UserC",
+                    "https://example.com/users/UserD",
+                    "https://example.com/users/UserE",
+                    "https://example.com/users/UserF",
+                    "https://example.com/users/UserG",
+                    "https://example.com/users/UserH",
+                    "https://example.com/users/UserI",
+                    "https://example.com/users/UserJ",
+                    "https://example.com/users/UserK",
+                    "https://example.com/users/UserL",
+                ]
+                .into_iter()
+                .map(|s| s.parse().unwrap())
+                .collect(),
+            )
+            .total_items(822847)
+            .build();
+
+        let page = CollectionPageBase::builder()
+            .next(
+                "https://example.com/users/User1/followers?page=2"
+                    .parse()
+                    .unwrap(),
+            )
+            .build();
+
+        let expected = OrderedCollectionPage::<ResourceUrl>::builder()
+            .base(collection_base)
+            .context(Context::default())
+            .id("https://example.com/users/User1/followers?page=1"
+                .parse::<UrlId<_>>()
+                .unwrap())
+            .page(page)
+            .build();
+
+        assert_eq!(expected, deserialized)
+    }
+}

--- a/crates/apub-activitypub/src/model/note.rs
+++ b/crates/apub-activitypub/src/model/note.rs
@@ -33,7 +33,9 @@ pub struct Note {
     content: String,
     published: Option<String>,
     to: Option<SingleOrMany<ResourceUrl>>,
+    cc: Option<SingleOrMany<ResourceUrl>>,
     in_reply_to: Option<UrlId<Note>>,
+    attributed_to: Option<ResourceUrl>,
 }
 
 impl Note {

--- a/crates/apub-activitypub/src/model/person.rs
+++ b/crates/apub-activitypub/src/model/person.rs
@@ -32,6 +32,8 @@ pub struct Person {
     inbox: ResourceUrl,
     #[builder(default, setter(strip_option))]
     shared_inbox: Option<ResourceUrl>,
+    #[builder(default, setter(strip_option))]
+    followers: Option<ResourceUrl>,
 }
 
 impl Object for Person {

--- a/crates/apub-activitypub/src/webfinger/webfinger_object.rs
+++ b/crates/apub-activitypub/src/webfinger/webfinger_object.rs
@@ -25,6 +25,17 @@ pub struct WebFinger {
     links: Vec<WebFingerLink>,
 }
 
+impl WebFinger {
+    /// `rel`が`self`なリンクを返す
+    pub fn me(&self) -> Option<&ResourceUrl> {
+        self.links
+            .iter()
+            .filter(|v| "self" == &v.rel)
+            .flat_map(|v| &v.href)
+            .next()
+    }
+}
+
 /// WebFinger link item
 #[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, PartialEq, TypedBuilder)]

--- a/crates/apub-adapter/src/model.rs
+++ b/crates/apub-adapter/src/model.rs
@@ -1,4 +1,4 @@
 pub(crate) mod follower;
+pub(crate) mod note;
 pub(crate) mod rsa_key;
 pub(crate) mod user;
-pub(crate)mod note;

--- a/crates/apub-adapter/src/model.rs
+++ b/crates/apub-adapter/src/model.rs
@@ -1,3 +1,4 @@
 pub(crate) mod follower;
 pub(crate) mod rsa_key;
 pub(crate) mod user;
+pub(crate)mod note;

--- a/crates/apub-adapter/src/model/note.rs
+++ b/crates/apub-adapter/src/model/note.rs
@@ -1,0 +1,24 @@
+use apub_kernel::note::model::Note;
+use sqlx::types::Uuid;
+
+pub struct NoteRow {
+    pub note_id: Uuid,
+    pub user_id: Uuid,
+    pub content: String,
+}
+
+impl From<NoteRow> for Note {
+    fn from(value: NoteRow) -> Self {
+        let NoteRow {
+            note_id,
+            user_id,
+            content,
+        } = value;
+
+        Note {
+            id: note_id.into(),
+            user_id: user_id.into(),
+            content,
+        }
+    }
+}

--- a/crates/apub-adapter/src/repository.rs
+++ b/crates/apub-adapter/src/repository.rs
@@ -1,5 +1,6 @@
 pub mod activity;
 pub mod follower;
+pub mod note;
 pub mod rsa_key;
 pub mod user;
 pub mod webfinger;

--- a/crates/apub-adapter/src/repository/note.rs
+++ b/crates/apub-adapter/src/repository/note.rs
@@ -1,0 +1,91 @@
+use apub_kernel::{
+    note::{
+        model::{CreateNote, Note, NoteId},
+        repository::NoteRepository,
+    },
+    user::model::UserId,
+};
+
+use crate::{model::note::NoteRow, persistence::postgres::PostgresDb};
+
+#[async_trait::async_trait]
+impl NoteRepository for PostgresDb {
+    #[tracing::instrument(skip(self))]
+    async fn find(&self, note_id: &NoteId) -> anyhow::Result<Note> {
+        let row = sqlx::query_as!(
+            NoteRow,
+            r#"
+            SELECT 
+                note_id, user_id, content
+            FROM
+                notes
+            WHERE
+                notes.note_id = $1
+        "#,
+            note_id.as_ref()
+        )
+        .fetch_one(self.inner_ref())
+        .await?;
+
+        Ok(row.into())
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn list_user_notes(&self, user_id: &UserId) -> anyhow::Result<Vec<Note>> {
+        let rows = sqlx::query_as!(
+            NoteRow,
+            r#"
+            SELECT 
+                note_id, user_id, content
+            FROM
+                notes
+            WHERE
+                notes.user_id = $1
+        "#,
+            user_id.as_ref()
+        )
+        .fetch_all(self.inner_ref())
+        .await?;
+
+        let notes = rows.into_iter().map(|r| r.into()).collect();
+
+        Ok(notes)
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn create(&self, event: &CreateNote) -> anyhow::Result<()> {
+        let _count = sqlx::query!(
+            r#"
+            INSERT INTO notes (note_id, user_id, content)
+            VALUES ($1,$2,$3)
+        "#,
+            event.note_id.as_ref(),
+            event.user_id.as_ref(),
+            event.content
+        )
+        .execute(self.inner_ref())
+        .await?;
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn delete(&self, note_id: &NoteId) -> anyhow::Result<()> {
+        let count = sqlx::query!(
+            r#"
+            DELETE FROM notes
+            WHERE
+                notes.note_id = $1
+        "#,
+            note_id.as_ref(),
+        )
+        .execute(self.inner_ref())
+        .await?;
+
+        if count.rows_affected() != 1 {
+            Err(anyhow::anyhow!("No rows deleted"))
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/crates/apub-api/src/handler/person.rs
+++ b/crates/apub-api/src/handler/person.rs
@@ -1,6 +1,11 @@
 use apub_activitypub::{
     core::actor::Actor as _,
-    model::{key::PublicKeyPem, person::SecurityPerson},
+    model::{
+        collection::{OrderedCollection, OrderedCollectionBase},
+        context::Context,
+        key::PublicKeyPem,
+        person::{Person, SecurityPerson},
+    },
     shared::activity_json::ActivityJson,
 };
 use apub_kernel::{prelude::*, rsa_key::model::RsaVerifyingKey};
@@ -38,7 +43,14 @@ pub async fn person_handler(
     let config = registry.config();
     let user_key_id = user.user_key_uri::<RsaVerifyingKey>(&config);
 
-    let person = user.to_person(&config);
+    let person = Person::builder()
+        .id(user.user_uri(&config))
+        .preferred_username(user.name.clone())
+        .inbox(user.inbox_uri(&config))
+        .context(Context::activity_context_url().clone().into())
+        .followers(user.followers_uri(&config))
+        .build();
+
     let person_id = person.id().clone();
 
     let public_key_pem = PublicKeyPem::builder()
@@ -55,4 +67,35 @@ pub async fn person_handler(
     tracing::info!(message = "Return person", name = username);
 
     Ok(ActivityJson(security))
+}
+
+pub async fn followers_handler(
+    username: &str,
+    registry: &impl AppRegistryExt,
+) -> Result<impl IntoResponse, PersonError> {
+    let user = registry.user_repository().find_by_name(username).await?;
+
+    let config = registry.config();
+
+    let followers = registry
+        .follower_repository()
+        .find_followee(&user.id)
+        .await?;
+
+    let follower_url = followers
+        .into_iter()
+        .map(|v| v.actor_url)
+        .collect::<Vec<_>>();
+
+    let follower_collection = OrderedCollectionBase::builder()
+        .total_items(follower_url.len())
+        .ordered_items(follower_url)
+        .build();
+    let follower_collection = OrderedCollection::builder()
+        .context(Context::activity_context_url().clone())
+        .id(user.followers_uri(&config))
+        .base(follower_collection)
+        .build();
+
+    Ok(ActivityJson(follower_collection))
 }

--- a/crates/apub-api/src/route/person.rs
+++ b/crates/apub-api/src/route/person.rs
@@ -1,4 +1,4 @@
-use crate::handler::person::{person_handler, PersonError};
+use crate::handler::person::{followers_handler, person_handler, PersonError};
 use apub_activitypub::shared::activity_json::ACTIVITY_CONTENT_TYPE;
 use apub_registry::AppRegistry;
 use axum::{
@@ -12,6 +12,16 @@ pub async fn person(
     State(registry): State<AppRegistry>,
 ) -> Result<impl IntoResponse, PersonError> {
     let res = person_handler(&username, &registry).await?;
+
+    Ok(([ACTIVITY_CONTENT_TYPE], res))
+}
+
+#[tracing::instrument(skip_all)]
+pub async fn followers(
+    Path(username): Path<String>,
+    State(registry): State<AppRegistry>,
+) -> Result<impl IntoResponse, PersonError> {
+    let res = followers_handler(&username, &registry).await?;
 
     Ok(([ACTIVITY_CONTENT_TYPE], res))
 }

--- a/crates/apub-api/src/route/send_note.rs
+++ b/crates/apub-api/src/route/send_note.rs
@@ -1,9 +1,10 @@
+use apub_activitypub::core::actor::Actor;
+use apub_activitypub::model::person::Person;
 use apub_activitypub::model::{activity::CreatePersonNote, context::Context, note::Note};
 use apub_kernel::prelude::*;
 use apub_kernel::repository::activity::{generate_activity_uri, generate_note_uri};
 use apub_kernel::rsa_key::model::RsaVerifyingKey;
 use apub_registry::{AppRegistry, AppRegistryExt};
-use apub_shared::model::resource_url::ResourceUrl;
 use axum::{
     extract::{Query, State},
     http::StatusCode,
@@ -14,7 +15,6 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 pub struct SendNoteQuery {
     message: String,
-    inbox: ResourceUrl,
     user: String,
 }
 
@@ -35,18 +35,12 @@ impl IntoResponse for SendNoteError {
     }
 }
 
-#[tracing::instrument(skip_all)]
-pub async fn send_note(
-    Query(query): Query<SendNoteQuery>,
-    State(registry): State<AppRegistry>,
-) -> Result<(), SendNoteError> {
+async fn send_note_handler(
+    query: &SendNoteQuery,
+    registry: impl AppRegistryExt,
+) -> Result<impl IntoResponse, SendNoteError> {
     let user_repo = registry.user_repository();
     let user = user_repo.find_by_name(&query.user).await?;
-
-    let user_signing_key = registry
-        .rsa_key_repository()
-        .find_private_key_or_generate(&user.id)
-        .await?;
 
     let config = registry.config();
     let note_uri = generate_note_uri(&config);
@@ -54,12 +48,7 @@ pub async fn send_note(
     let note = Note::builder()
         .id(note_uri.into())
         .content(format!("<p>{}</p>", query.message))
-        .in_reply_to(
-            "https://activitypub.academy/@dodatus_dranapat/113530116833625285"
-                .parse::<ResourceUrl>()
-                .unwrap()
-                .into(),
-        )
+        .attributed_to(user.user_uri(&config).into())
         .to(Note::public_address().clone().into())
         .build();
 
@@ -74,14 +63,40 @@ pub async fn send_note(
         .build();
 
     let activity_repo = registry.activity_repository();
-    activity_repo
-        .post_note(
-            &create,
-            &query.inbox,
-            &user_signing_key,
-            &user.user_key_uri::<RsaVerifyingKey>(&config),
-        )
+    let user_signing_key = registry
+        .rsa_key_repository()
+        .find_private_key_or_generate(&user.id)
+        .await?;
+    let user_key_id = user.user_key_uri::<RsaVerifyingKey>(&config);
+
+    let followers = registry
+        .follower_repository()
+        .find_followee(&user.id)
         .await?;
 
-    Ok(())
+    for v in followers {
+        // 都度フォロワーに問い合わせて、inboxを取得する
+        let follow_person = activity_repo
+            .get_activity::<Person>(&v.actor_url, &user_signing_key, &user_key_id)
+            .await?;
+
+        activity_repo
+            .post_note(
+                &create,
+                follow_person.inbox(),
+                &user_signing_key,
+                &user.user_key_uri::<RsaVerifyingKey>(&config),
+            )
+            .await?;
+    }
+
+    Ok(StatusCode::CREATED)
+}
+
+#[tracing::instrument(skip_all)]
+pub async fn send_note(
+    Query(query): Query<SendNoteQuery>,
+    State(registry): State<AppRegistry>,
+) -> Result<impl IntoResponse, SendNoteError> {
+    send_note_handler(&query, registry).await
 }

--- a/crates/apub-kernel/src/lib.rs
+++ b/crates/apub-kernel/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod follower;
 pub mod model;
+pub mod note;
 pub mod prelude;
 pub mod repository;
 pub mod rsa_key;

--- a/crates/apub-kernel/src/note.rs
+++ b/crates/apub-kernel/src/note.rs
@@ -1,0 +1,2 @@
+pub mod model;
+pub mod repository;

--- a/crates/apub-kernel/src/note/model.rs
+++ b/crates/apub-kernel/src/note/model.rs
@@ -1,0 +1,42 @@
+use apub_config::AppConfig;
+use apub_shared::model::{id::Id, resource_url::ResourceUrl};
+
+use crate::user::model::UserId;
+
+pub type NoteId = Id<Note>;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Note {
+    pub id: NoteId,
+    pub user_id: UserId,
+    pub content: String,
+}
+
+impl Note {
+    pub fn note_uri(&self, config: &AppConfig) -> ResourceUrl {
+        let note_uri = config
+            .host_uri()
+            .clone()
+            .set_path(&format!("/notes/{}", self.id))
+            .to_owned();
+        note_uri
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CreateNote {
+    pub note_id: NoteId,
+    pub user_id: UserId,
+    pub content: String,
+}
+
+impl CreateNote {
+    pub fn new(user_id: UserId, content: String) -> Self {
+        let note_id = NoteId::new();
+        Self {
+            note_id,
+            user_id,
+            content,
+        }
+    }
+}

--- a/crates/apub-kernel/src/note/model.rs
+++ b/crates/apub-kernel/src/note/model.rs
@@ -1,9 +1,10 @@
 use apub_config::AppConfig;
-use apub_shared::model::{id::Id, resource_url::ResourceUrl};
+use apub_shared::model::id::{Id, UrlId};
 
 use crate::user::model::UserId;
 
 pub type NoteId = Id<Note>;
+pub type NoteUrl = UrlId<Note>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Note {
@@ -13,13 +14,13 @@ pub struct Note {
 }
 
 impl Note {
-    pub fn note_uri(&self, config: &AppConfig) -> ResourceUrl {
+    pub fn note_uri(&self, config: &AppConfig) -> NoteUrl {
         let note_uri = config
             .host_uri()
             .clone()
             .set_path(&format!("/notes/{}", self.id))
             .to_owned();
-        note_uri
+        note_uri.into()
     }
 }
 

--- a/crates/apub-kernel/src/note/repository.rs
+++ b/crates/apub-kernel/src/note/repository.rs
@@ -1,0 +1,11 @@
+use crate::user::model::UserId;
+
+use super::model::{CreateNote, Note, NoteId};
+
+#[async_trait::async_trait]
+pub trait NoteRepository: Send + Sync {
+    async fn find(&self, note_id: &NoteId) -> anyhow::Result<Note>;
+    async fn list_user_notes(&self, user_id: &UserId) -> anyhow::Result<Vec<Note>>;
+    async fn create(&self, event: &CreateNote) -> anyhow::Result<()>;
+    async fn delete(&self, note_id: &NoteId) -> anyhow::Result<()>;
+}

--- a/crates/apub-kernel/src/prelude.rs
+++ b/crates/apub-kernel/src/prelude.rs
@@ -1,4 +1,5 @@
 pub use crate::repository::activity::ActivityRepository;
 
+pub use crate::follower::repository::FollowerRepository;
 pub use crate::rsa_key::repository::RsaKeyRepository;
 pub use crate::user::repository::UserRepository;

--- a/crates/apub-kernel/src/user/model.rs
+++ b/crates/apub-kernel/src/user/model.rs
@@ -40,6 +40,16 @@ impl User {
         inbox_uri
     }
 
+    /// `/users/{username}/followers`
+    pub fn followers_uri(&self, config: &AppConfig) -> ResourceUrl {
+        let followers_uri = config
+            .host_uri()
+            .clone()
+            .set_path(&format!("/users/{}/followers", self.name))
+            .to_owned();
+        followers_uri
+    }
+
     /// `/users/{username}#keyname`
     pub fn user_key_uri<T>(&self, config: &AppConfig) -> ResourceUrl
     where

--- a/crates/apub-registry/src/lib.rs
+++ b/crates/apub-registry/src/lib.rs
@@ -2,20 +2,22 @@ use std::sync::Arc;
 
 use apub_adapter::persistence::{http_client::HttpClient, postgres::PostgresDb};
 use apub_config::AppConfig;
-use apub_kernel::{follower::repository::FollowerRepository, prelude::*};
+use apub_kernel::{
+    follower::repository::FollowerRepository, note::repository::NoteRepository, prelude::*,
+};
 
 #[derive(Clone)]
 pub struct AppRegistry {
-    postgres: Arc<PostgresDb>,
-    http_client: Arc<HttpClient>,
+    postgres: PostgresDb,
+    http_client: HttpClient,
     config: Arc<AppConfig>,
 }
 
 impl AppRegistry {
     pub fn new_postgres(pool: PostgresDb, config: AppConfig) -> Self {
         AppRegistry {
-            postgres: Arc::new(pool),
-            http_client: Arc::new(HttpClient::new()),
+            postgres: pool,
+            http_client: HttpClient::new(),
             config: Arc::new(config),
         }
     }
@@ -25,19 +27,24 @@ impl AppRegistryExt for AppRegistry {
     type UserRepo = PostgresDb;
     type RsaRepo = PostgresDb;
     type FollowerRepo = PostgresDb;
+    type NoteRepo = PostgresDb;
     type ActivityRepo = HttpClient;
-    fn user_repository(&self) -> Arc<Self::UserRepo> {
+    fn user_repository(&self) -> Self::UserRepo {
         self.postgres.clone()
     }
-    fn rsa_key_repository(&self) -> Arc<Self::RsaRepo> {
+    fn rsa_key_repository(&self) -> Self::RsaRepo {
         self.postgres.clone()
     }
 
-    fn activity_repository(&self) -> Arc<Self::ActivityRepo> {
+    fn activity_repository(&self) -> Self::ActivityRepo {
         self.http_client.clone()
     }
 
-    fn follower_repository(&self) -> Arc<Self::FollowerRepo> {
+    fn follower_repository(&self) -> Self::FollowerRepo {
+        self.postgres.clone()
+    }
+
+    fn note_repository(&self) -> Self::NoteRepo {
         self.postgres.clone()
     }
 
@@ -51,9 +58,11 @@ pub trait AppRegistryExt: Send + Sync {
     type RsaRepo: RsaKeyRepository;
     type FollowerRepo: FollowerRepository;
     type ActivityRepo: ActivityRepository;
-    fn user_repository(&self) -> Arc<Self::UserRepo>;
-    fn rsa_key_repository(&self) -> Arc<Self::RsaRepo>;
-    fn activity_repository(&self) -> Arc<Self::ActivityRepo>;
-    fn follower_repository(&self) -> Arc<Self::FollowerRepo>;
+    type NoteRepo: NoteRepository;
+    fn user_repository(&self) -> Self::UserRepo;
+    fn rsa_key_repository(&self) -> Self::RsaRepo;
+    fn activity_repository(&self) -> Self::ActivityRepo;
+    fn follower_repository(&self) -> Self::FollowerRepo;
+    fn note_repository(&self) -> Self::NoteRepo;
     fn config(&self) -> Arc<AppConfig>;
 }

--- a/crates/apub-registry/src/lib.rs
+++ b/crates/apub-registry/src/lib.rs
@@ -46,7 +46,7 @@ impl AppRegistryExt for AppRegistry {
     }
 }
 
-pub trait AppRegistryExt {
+pub trait AppRegistryExt: Send + Sync {
     type UserRepo: UserRepository;
     type RsaRepo: RsaKeyRepository;
     type FollowerRepo: FollowerRepository;

--- a/crates/apub-shared/src/model/id.rs
+++ b/crates/apub-shared/src/model/id.rs
@@ -31,6 +31,12 @@ impl<T> From<ResourceUrl> for UrlId<T> {
     }
 }
 
+impl<T> AsRef<ResourceUrl> for UrlId<T> {
+    fn as_ref(&self) -> &ResourceUrl {
+        &self.resource_url
+    }
+}
+
 impl<T> From<UrlId<T>> for ResourceUrl {
     fn from(value: UrlId<T>) -> Self {
         value.resource_url

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,10 @@ async fn bootstrap() -> anyhow::Result<()> {
         .route("/health", routing::get(health_check))
         .route("/users/:username", routing::get(person::person))
         .route(
+            "/users/:username/followers",
+            routing::get(person::followers),
+        )
+        .route(
             "/users/:username/inbox",
             routing::post(user_inbox::user_inbox),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,17 +72,21 @@ async fn seed_db(registry: &AppRegistry) -> anyhow::Result<()> {
     use apub_kernel::prelude::*;
     let user_repo = registry.user_repository();
 
-    user_repo
-        .create(CreateUser {
+    UserRepository::create(
+        &user_repo,
+        CreateUser {
             name: "alice".to_string(),
-        })
-        .await?;
+        },
+    )
+    .await?;
 
-    user_repo
-        .create(CreateUser {
+    UserRepository::create(
+        &user_repo,
+        CreateUser {
             name: "bob".to_string(),
-        })
-        .await?;
+        },
+    )
+    .await?;
 
     Ok(())
 }


### PR DESCRIPTION
## フォロワーに対して`Note`を送信する機能の作成

ユーザのフォロワーに対して、公開で`Create`アクティビティを送信する機能の実装

## スクショ

![image](https://github.com/user-attachments/assets/efa41e59-2798-4974-9760-4d92d43b8d5d)

![image](https://github.com/user-attachments/assets/0472731c-4657-46d0-bfff-1b7c90ba59df)

## メモ

毎回ユーザの`inbox`を調べているので、DBに格納したほうが間違いなく良い